### PR TITLE
v0.5.2 - Output json file errors and optional baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 component-bundle-sizes.json
+compsizer-failure-report.json

--- a/BundleSizeAnalyser.js
+++ b/BundleSizeAnalyser.js
@@ -40,6 +40,7 @@ class BundleSizeAnalyser {
     }
 
     async loadBaseline(baselineFile) {
+        if (!baselineFile) return null;
         const baselinePath = this.path.resolve(process.cwd(), baselineFile);
         try {
             const baselineContent = await this.fs.readFile(baselinePath, 'utf8');
@@ -67,7 +68,7 @@ class BundleSizeAnalyser {
     }
 
     async calculateSizes(filePaths, compression) {
-        const fileContents = await this.batchReadFiles(filePaths);  // Read all files in parallel
+        const fileContents = await this.batchReadFiles(filePaths);
 
         const sizePromises = fileContents.map(async (fileContent, index) => {
             const fileSize = fileContent.length;
@@ -91,7 +92,6 @@ class BundleSizeAnalyser {
 
         const results = await Promise.all(sizePromises);
 
-        // Aggregate results
         const totalSize = results.reduce((acc, result) => acc + result.fileSize, 0);
         const totalGzipSize = results.reduce((acc, result) => acc + result.gzipSize, 0);
         const totalBrotliSize = results.reduce((acc, result) => acc + result.brotliSize, 0);
@@ -104,7 +104,7 @@ class BundleSizeAnalyser {
     }
 
     compareSizes(result, componentName, baselineSizes, config) {
-        const { maxSize, warnOnIncrease } = config;
+        const { maxSize, warnOnIncrease = null } = config;
         const maxSizeValue = this.parseSize(maxSize);
 
         const exceedsMaxSize = maxSizeValue !== null && result.totalSizeKB * 1024 > maxSizeValue;
@@ -117,22 +117,28 @@ class BundleSizeAnalyser {
             });
         }
 
-        const previousSize = baselineSizes[componentName] || 0;
-        const sizeIncrease = result.totalSizeKB * 1024 - previousSize;
-        const percentageIncrease = previousSize
-            ? ((sizeIncrease / previousSize) * 100).toFixed(2)
-            : 'N/A';
-
+        let sizeIncrease = 0;
+        let percentageIncrease = 'N/A';
         let exceedsWarnIncrease = false;
-        if (previousSize && warnOnIncrease) {
-            const warnIncreaseValue = this.parsePercentage(warnOnIncrease);
-            if (
-                warnIncreaseValue !== null &&
-                percentageIncrease !== 'N/A' &&
-                percentageIncrease > warnIncreaseValue
-            ) {
-                exceedsWarnIncrease = true;
-                this.hasWarnings = true;
+
+        // Only perform baseline comparisons if baselineSizes is provided
+        if (baselineSizes) {
+            const previousSize = baselineSizes[componentName] || 0;
+            sizeIncrease = result.totalSizeKB * 1024 - previousSize;
+            percentageIncrease = previousSize
+                ? ((sizeIncrease / previousSize) * 100).toFixed(2)
+                : 'N/A';
+
+            if (previousSize && warnOnIncrease) {
+                const warnIncreaseValue = this.parsePercentage(warnOnIncrease);
+                if (
+                    warnIncreaseValue !== null &&
+                    percentageIncrease !== 'N/A' &&
+                    percentageIncrease > warnIncreaseValue
+                ) {
+                    exceedsWarnIncrease = true;
+                    this.hasWarnings = true;
+                }
             }
         }
 
@@ -143,7 +149,7 @@ class BundleSizeAnalyser {
             sizeIncreaseKB: sizeIncrease / 1024,
             percentageIncrease,
             exceedsWarnIncrease,
-            warnOnIncrease,
+            warnOnIncrease: baselineSizes ? warnOnIncrease : null,
         };
     }
 
@@ -203,10 +209,11 @@ class BundleSizeAnalyser {
     }
 
     async updateBaseline(baselineFile) {
+        if (!baselineFile) return;
         const baselinePath = this.path.resolve(process.cwd(), baselineFile);
         const newBaselineSizes = {};
         for (const [componentName, result] of Object.entries(this.results)) {
-            newBaselineSizes[componentName] = result.totalSizeKB * 1024; // Store in bytes
+            newBaselineSizes[componentName] = result.totalSizeKB * 1024;
         }
         await this.fs.writeFile(baselinePath, JSON.stringify(newBaselineSizes, null, 2));
     }
@@ -243,7 +250,7 @@ class BundleSizeAnalyser {
         for (const [componentName, componentConfig] of Object.entries(components)) {
             const {
                 maxSize,
-                warnOnIncrease = defaults.warnOnIncrease || '5%',
+                warnOnIncrease = defaults?.warnOnIncrease || null,
                 distFolderLocation,
                 exclude: componentExclude = exclude
             } = componentConfig;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Output failures as a JSON report file named `compsizer-failure-report.json`
+- Make baseline file and warn thresholds optional
 
 ## [0.4.2] - 20-10-2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 25-10-2024
+
+### Changed
+
+- Output failures as a JSON report file named `compsizer-failure-report.json`
 
 ## [0.4.2] - 20-10-2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.1] - 01-11-2024
+## [0.5.2] - 01-11-2024
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 25-10-2024
+## [0.5.0] - 01-11-2024
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - 01-11-2024
+## [0.5.1] - 01-11-2024
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -88,18 +88,19 @@ Each component package should have its own configuration file to specify the inc
     "gzip": true,
     "brotli": true
   },
-  "baselineFile": "component-bundle-sizes.json",
+  "baselineFile": "component-bundle-sizes.json", // Optional - if not provided, no baseline comparison takes place
   "components": {
     "modal": {
       "maxSize": "50 KB",
-      "warnOnIncrease": "10%",
+      "warnOnIncrease": "10%", // Optional
       "distFolderLocation": "./dist"
     },
     // You could add more components here if placing this config at the root of your project.
   },
-  "defaults": {
+  "defaults": { // Optional
     "warnOnIncrease": "5%"
   }
+}
 ```
 
 ### Configuration Fields
@@ -111,11 +112,11 @@ Each component package should have its own configuration file to specify the inc
 - **baselineFile**: (string) Path to the JSON file where the baseline sizes are stored.
 - **components**: (object) Configuration for each component. Each key corresponds to a component name.
   - `maxSize`: (string) The maximum allowable size for the component (e.g., `50KB`, `500KB`).
-  - `warnOnIncrease`: (string) Warn if the size increases by more than the specified percentage.
+  - `warnOnIncrease`: (string) OPTIONAL: Warn if the size increases by more than the specified percentage.
   - `distFolderLocation`: (string) Path pointing to the built component files.
   - `exclude`: (array) Glob patterns specific to the component to exclude. (Overrides the base `exclude`)
-- **defaults**: (object) Default settings that apply to all components.
-  - `warnOnIncrease`: (string) Default warning threshold for size increases.
+- **defaults**: (object) OPTIONAL: Default settings that apply to all components.
+  - `warnOnIncrease`: (string) OPTIONAL: Default warning threshold for size increases.
 
 ### Adding Config for Each Component
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compsizer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compsizer",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compsizer",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compsizer",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compsizer",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A tool for analysing the size of component packages in your monorepo.",
   "type": "module",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compsizer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A tool for analysing the size of component packages in your monorepo.",
   "type": "module",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compsizer",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "A tool for analysing the size of component packages in your monorepo.",
   "type": "module",
   "main": "index.js",

--- a/test/compsizer.config.json
+++ b/test/compsizer.config.json
@@ -6,15 +6,10 @@
     "gzip": true,
     "brotli": true
   },
-  "baselineFile": "component-bundle-sizes.json",
   "components": {
     "testComponent": {
       "maxSize": "96 KB",
-      "warnOnIncrease": "10%",
       "distFolderLocation": "./test/testEnv"
     }
-  },
-  "defaults": {
-    "warnOnIncrease": "5%"
   }
 }


### PR DESCRIPTION
## [0.5.0] - 01-11-2024

### Changed

- Output failures as a JSON report file named `compsizer-failure-report.json`
- Make baseline file and warn thresholds optional